### PR TITLE
Relax requirements for hocr files to be processed

### DIFF
--- a/hocr2alto2.0.xsl
+++ b/hocr2alto2.0.xsl
@@ -55,7 +55,7 @@ License: MIT License (MIT)
             <Page ID="{@id}" PHYSICAL_IMG_NR="1" HEIGHT="{$box[5]}" WIDTH="{$box[4]}">
                 <PrintSpace HEIGHT="{$box[5]}" WIDTH="{$box[4]}" VPOS="0" HPOS="0">
 
-                    <xsl:apply-templates select="*:div[@class='ocr_carea']"/>
+                    <xsl:apply-templates/>
 
                 </PrintSpace>
             </Page>
@@ -67,7 +67,7 @@ License: MIT License (MIT)
       <xsl:variable name="box" select="tokenize(mf:getBox(@title), ' ')"/>
       <ComposedBlock ID="{@id}" HEIGHT="{number($box[5]) - number($box[3])}" WIDTH="{number($box[4]) - number($box[2])}" VPOS="{$box[3]}" HPOS="{$box[2]}">
       
-          <xsl:apply-templates select="*:p[@class='ocr_par']"/>
+          <xsl:apply-templates/>
 
       </ComposedBlock>
   </xsl:template>
@@ -99,7 +99,7 @@ License: MIT License (MIT)
 
           </xsl:choose>
       
-          <xsl:apply-templates select="*:span[@class='ocr_line']"/>
+          <xsl:apply-templates/>
       
       </TextBlock>
   </xsl:template>

--- a/hocr2alto2.0.xsl
+++ b/hocr2alto2.0.xsl
@@ -109,7 +109,13 @@ License: MIT License (MIT)
       <xsl:variable name="box" select="tokenize(mf:getBox(@title), ' ')"/>
       <TextLine ID="{@id}" HEIGHT="{number($box[5]) - number($box[3])}" WIDTH="{number($box[4]) - number($box[2])}" VPOS="{$box[3]}" HPOS="{$box[2]}">
       
-          <xsl:apply-templates select="*:span[@class='ocrx_word']"/>
+          <xsl:when test="*:span[@class='ocrx_word']">
+              <xsl:apply-templates select="*:span[@class='ocrx_word']"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <String CONTENT="{normalize-space(.)}"/>
+            </xsl:otherwise>
+          </xsl:choose>
       
       </TextLine>
   </xsl:template>

--- a/hocr2alto2.1.xsl
+++ b/hocr2alto2.1.xsl
@@ -60,7 +60,7 @@ License: MIT License (MIT)
         <Page ID="{@id}" PHYSICAL_IMG_NR="1" HEIGHT="{$box[5]}" WIDTH="{$box[4]}">
             <PrintSpace HEIGHT="{$box[5]}" WIDTH="{$box[4]}" VPOS="0" HPOS="0">
 
-                <xsl:apply-templates select="*:div[@class='ocr_carea']"/>
+                <xsl:apply-templates/>
 
             </PrintSpace>
         </Page>
@@ -71,7 +71,7 @@ License: MIT License (MIT)
       <xsl:variable name="box" select="tokenize(mf:getBox(@title), ' ')"/>
       <ComposedBlock ID="{@id}" HEIGHT="{number($box[5]) - number($box[3])}" WIDTH="{number($box[4]) - number($box[2])}" VPOS="{$box[3]}" HPOS="{$box[2]}">
       
-          <xsl:apply-templates select="*:p[@class='ocr_par']"/>
+          <xsl:apply-templates/>
 
       </ComposedBlock>
   </xsl:template>
@@ -103,7 +103,7 @@ License: MIT License (MIT)
 
           </xsl:choose>
       
-          <xsl:apply-templates select="*:span[@class='ocr_line']"/>
+          <xsl:apply-templates/>
       
       </TextBlock>
   </xsl:template>

--- a/hocr2alto2.1.xsl
+++ b/hocr2alto2.1.xsl
@@ -113,7 +113,13 @@ License: MIT License (MIT)
       <xsl:variable name="box" select="tokenize(mf:getBox(@title), ' ')"/>
       <TextLine ID="{@id}" HEIGHT="{number($box[5]) - number($box[3])}" WIDTH="{number($box[4]) - number($box[2])}" VPOS="{$box[3]}" HPOS="{$box[2]}">
       
-          <xsl:apply-templates select="*:span[@class='ocrx_word']"/>
+          <xsl:when test="*:span[@class='ocrx_word']">
+              <xsl:apply-templates select="*:span[@class='ocrx_word']"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <String CONTENT="{normalize-space(.)}"/>
+            </xsl:otherwise>
+          </xsl:choose>
       
       </TextLine>
   </xsl:template>


### PR DESCRIPTION
This allows to process hocr files which are not having all the hierarchical layers in this order, e.g. from
ocropus as for example https://github.com/kba/ocr-fileformat-samples/blob/master/samples/hocr/1.1/433934212_0017.html only has ocr_line and ocr_page.