### PR TITLE
Adjust ocr_capabilities

### DIFF
--- a/dev/alto__hocr.xsl
+++ b/dev/alto__hocr.xsl
@@ -42,14 +42,7 @@ License: MIT
       <title>Image: <xsl:apply-templates select="*:sourceImageInformation"/></title>
       <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
       <xsl:apply-templates select="*:OCRProcessing/*:ocrProcessingStep"/>
-      
-      <xsl:choose>
-        <xsl:when test="//*:ComposedBlock">
-          <meta name='ocr-capabilities' content='ocr_page ocr_carea ocr_par ocr_line ocrx_word' />
-        </xsl:when>
-        <xsl:otherwise><meta name='ocr-capabilities' content='ocr_page ocr_par ocr_line ocrx_word' /></xsl:otherwise>
-      </xsl:choose>
-      
+      <meta name='ocr-capabilities' content='ocr_page ocr_header ocr_footer ocr_carea ocr_par ocr_line ocrx_word' />
     </head>
   </xsl:template>
   


### PR DESCRIPTION
Actually this also reverts #11 because according to the specs
one has to list of which elements the tool is capable of generating
independent whether they occur or not in the current document.
See also http://kba.cloud/hocr-spec/1.2/#capabilities .