### PR TITLE
Revert "Fix the xml version"

### DIFF
--- a/alto__text.xsl
+++ b/alto__text.xsl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 <!--
 Author:  konstantin baierer
 License: MIT

--- a/hocr__text.xsl
+++ b/hocr__text.xsl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 <!--
 Author:  konstantin baierer
 License: MIT


### PR DESCRIPTION
This reverts commit ec3c27f5989920a8ec3b5313cd76cf8671691435.

This fixes https://github.com/UB-Mannheim/ocr-fileformat/issues/185.